### PR TITLE
Changes for the latest AWS Icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,6 @@ Download or clone this repository
 git clone https://github.com/willthames/aws-inkscape-symbols
 ```
 
-Install requirements (currently only ElementTree)
-```
-pip install -r requirements.txt
-```
-
 ## Generation of symbols
 
 Download the latest AWS Symbol set in EPS/SVG format

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+PATH=$PATH:/sbin
 set -e
 
 if [ $# -ne 1 ]; then
@@ -13,8 +13,16 @@ rm -rf target build
 mkdir target build
 
 tempdir=`mktemp -d`
-unzip -q $zipfile "*.svg" -d $tempdir
-rsync -av $tempdir/AWS*/ build --exclude GRAYSCALE/* --exclude __MACOSX
+
+bsdtar=`which bsdtar`
+if [ -f "$bsdtar" ]; then
+  bsdtar -xf $zipfile -s'|[^/]*/||' --include='*.svg' --exclude="._*" -C $tempdir
+  rsync -av $tempdir/ build --exclude GRAYSCALE/* --exclude __MACOSX
+else
+  unzip -q $zipfile "*.svg" -d $tempdir
+  rsync -av $tempdir/PNG*/ build --exclude GRAYSCALE/* --exclude __MACOSX
+fi
+
 rm -rf $tempdir
 
 for dir in build/*; do

--- a/dir_to_svg.py
+++ b/dir_to_svg.py
@@ -5,6 +5,7 @@ import re
 import sys
 import xml.etree.ElementTree as ET
 
+#FILENAME_PREFIX = r'^[^_]*_(?:.*)?'
 FILENAME_PREFIX = r'^[^_]*_(?:Amazon|AWS)?'
 
 DIR_TO_CATEGORY = {
@@ -49,10 +50,21 @@ def read_component(filename):
     component = ET.Element('symbol', attrib=dict(id=symbol_id))
     title = ET.SubElement(component, 'title')
     title.text = symbol_id
+    defs = root.find('{http://www.w3.org/2000/svg}defs')
+    if defs is not None:
+        for style in defs.iter():
+            component.extend(style)
     # Explicitly set stroke-width otherwise symbols can be
     # a little heavy
-    gcontainer = root.find('{http://www.w3.org/2000/svg}g')
+    for defs in root.findall('{http://www.w3.org/2000/svg}defs'):
+      root.remove(defs)
+    for rt in root.findall('{http://www.w3.org/2000/svg}title'):
+      root.remove(rt)
+    gcontainer = root
+    #gcontainer = root.find('{http://www.w3.org/2000/svg}g')
     if gcontainer is not None:
+        component.extend(gcontainer)
+        """
         for gelem in gcontainer.iter():
             # only update leaf elements
             if not list(gelem):
@@ -61,7 +73,7 @@ def read_component(filename):
                         gelem.attrib['style'] += '; stroke-width: 1'
                 else:
                     gelem.attrib['style'] = 'stroke-width: 1'
-        component.extend(gcontainer)
+        """
     return component
 
 

--- a/dir_to_svg.py
+++ b/dir_to_svg.py
@@ -61,19 +61,8 @@ def read_component(filename):
     for rt in root.findall('{http://www.w3.org/2000/svg}title'):
       root.remove(rt)
     gcontainer = root
-    #gcontainer = root.find('{http://www.w3.org/2000/svg}g')
     if gcontainer is not None:
         component.extend(gcontainer)
-        """
-        for gelem in gcontainer.iter():
-            # only update leaf elements
-            if not list(gelem):
-                if 'style' in gelem.attrib:
-                    if 'stroke-width' not in gelem.attrib['style']:
-                        gelem.attrib['style'] += '; stroke-width: 1'
-                else:
-                    gelem.attrib['style'] = 'stroke-width: 1'
-        """
     return component
 
 

--- a/symbols_template.xml
+++ b/symbols_template.xml
@@ -6,8 +6,7 @@
    width="720"
    height="1008"
    viewBox="0,0,720,1008"
-   version="1.1"
-   style="fill:black;stroke:black">
+   version="1.1">
    <title/>
    <desc/>
   <metadata>


### PR DESCRIPTION
Hello. I made changes for the latest AWS Icons. Latest svg files not consist of the <g> element. So this is the main changes. Also was changed build.sh to use bsdtart or unzip. And from symbols_template.xml were removed style, because aws have their own stiles in the svg. Thanks.