### PR TITLE
Hopefully this does the right thing with subdirectories

### DIFF
--- a/dir_to_svg.py
+++ b/dir_to_svg.py
@@ -66,6 +66,17 @@ def read_component(filename):
     return component
 
 
+def read_subdir(srcdir):
+    components = list()
+    for maybe_filename in os.listdir(srcdir):
+        print("Maybe filename is {}".format(maybe_filename))
+        if not os.path.isdir(os.path.join(srcdir, maybe_filename)):
+            components.append(read_component(os.path.join(srcdir, maybe_filename)))
+        else:
+            new_srcdir = "{}/{}".format(srcdir, maybe_filename)  # not really a filename
+            components.extend(read_subdir(new_srcdir))
+    return components
+
 def main(args):
     ET.register_namespace('', 'http://www.w3.org/2000/svg')
     srcdir = args[0]
@@ -73,8 +84,9 @@ def main(args):
     destdir = args[1]
     componentname = DIR_TO_CATEGORY.get(subdir, subdir.lower())
     destfile = os.path.join(destdir, 'aws-%s.svg' % componentname)
-    components = [read_component(os.path.join(srcdir, filename))
-                  for filename in os.listdir(srcdir)]
+
+    components = read_subdir(srcdir)
+
     create_svg_file(componentname, destfile, components)
 
 


### PR DESCRIPTION
master breaks with current aws icon symbols:
```
sent 1,954,890 bytes  received 21,264 bytes  3,952,308.00 bytes/sec
total size is 1,864,357  speedup is 0.94
Traceback (most recent call last):
  File "dir_to_svg.py", line 82, in <module>
    sys.exit(main(sys.argv[1:]))
  File "dir_to_svg.py", line 77, in main
    for filename in os.listdir(srcdir)]
  File "dir_to_svg.py", line 45, in read_component
    tree = ET.parse(filename)
  File "/home/spacey/.pyenv/versions/2.7.12/lib/python2.7/xml/etree/ElementTree.py", line 1182, in parse
    tree.parse(source, parser)
  File "/home/spacey/.pyenv/versions/2.7.12/lib/python2.7/xml/etree/ElementTree.py", line 647, in parse
    source = open(source, "rb")
IOError: [Errno 21] Is a directory: 'build/Compute/_Instance'
```
This PR checks for subdirectories and descends into them instead of dying per the above.